### PR TITLE
Exposure of unsafe blocks

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: rust-build-test
 
 on:
   push:
@@ -10,24 +10,44 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_test_linux:
+  x86_64-unknown-linux-gnu:
 
     runs-on: ubuntu-latest
+    name: x86_64-unknown-linux-gnu
 
     steps:
     - uses: actions/checkout@v2
-    - name: Linux(Ubuntu) build
-      run: cargo build --verbose
-    - name: Run Linux(Ubuntu) tests
-      run: cargo test --verbose
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: x86_64-unknown-linux-gnu
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release --verbose
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --release --verbose
 
-  build_test_windows:
+  x86_64-pc-windows-msvc:
 
     runs-on: windows-latest
+    name: x86_64-pc-windows-msvc
 
     steps:
     - uses: actions/checkout@v2
-    - name: Windows build
-      run: cargo build --verbose
-    - name: Run Windows tests
-      run: cargo test --verbose
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: x86_64-pc-windows-msvc
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release --verbose
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --release --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,17 @@ keywords    = ["shared", "memory", "ipc", "inter", "communication"]
 license     = "Apache-2.0"
 name        = "typed_shmem"
 repository  = "https://www.github.com/UpsettingBoy/typed_shmem"
-version     = "0.2.1"
+version     = "0.3.0"
 
 
 [dependencies]
 cfg-if    = "1.0.0"
 getrandom = "0.2.0"
 oorandom  = "11.1.2"
-zerocopy  = "0.3.0"
+zerocopy  = "0.4.0"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.19.0"
+nix = "0.20.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["errhandlingapi", "handleapi", "memoryapi", "winerror"] }

--- a/README.md
+++ b/README.md
@@ -1,40 +1,44 @@
 # typed_shmem
-Exposes shared memory on *nix and Windows using mapped files. This work is heavily inspired on the [shared_memory](https://crates.io/crates/shared_memory) crate, but instead of being just a copy cat, **typed_shmem** provides a typed mapping into the shared region.
+Exposes shared memory on *nix and Windows using mapped files. This work is heavily inspired on the [shared_memory](https://crates.io/crates/shared_memory) crate, but instead of being just a copy cat, **typed_shmem** provides a typed mapping into the shared memory region.
 
 ## Usage
-**typed_shmem** is in an early development stage, thus some major changes could be required.
 First, a process must create the shared region:
 ```rust
 use typed_shmem as sh;
 use typed_shmem::error::ShMemErr;
+use typed_shmem::common::ShMemOps;
 
 fn main() -> Result<(), ShMemErr> {
     let mut mem = sh::ShMemCfg::<u32>::default()
-         .set_owner()
-         .on_file("test_program")
-         .build()?;
-    
-    // ShMem<T> implements Deref and DerefMut.
-    *mem = 10; //Write.
-    assert_eq!(*mem, 10); //Read.
-    
+        .set_owner()
+        .on_file("test_program")
+        .build()?;
+
+    //Writing
+    unsafe { *mem.get_t_mut() = 10; }
+
+    //Reading
+    let val = unsafe { mem.get_t() };
+    assert_eq!(*val, 10);
+
     loop {} //Used to keep the process alive, thus the allocated shared memory too.
-    
+     
     Ok(())
-}
 ```
 
 Then, any other process can join the same region:
 ```rust
 use typed_shmem as sh;
 use typed_shmem::error::ShMemErr;
+use typed_shmem::common::ShMemOps;
 
 fn main() -> Result<(), ShMemErr> {
     let mut mem = sh::ShMemCfg::<u32>::default()
              .on_file("test_program")
              .build()?;
     
-    assert_eq!(*mem, 10); //Read.
+    let val = unsafe { mem.get_t() };
+    assert_eq!(*val, 10);
     
     Ok(())
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,6 +4,6 @@ pub(crate) trait ShMemOps<T>
 where
     T: AsBytes + FromBytes + Default,
 {
-    fn get_t(&self) -> &T;
-    fn get_t_mut(&mut self) -> &mut T;
+    unsafe fn get_t(&self) -> &T;
+    unsafe fn get_t_mut(&mut self) -> &mut T;
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,9 +1,19 @@
 use zerocopy::{AsBytes, FromBytes};
 
-pub(crate) trait ShMemOps<T>
+/// Controls how a memory region can be accessed.
+/// See the implementation details of `ShObj` under *nix and Windows
+/// for hints on how this can backfire.
+pub trait ShMemOps<T>
 where
     T: AsBytes + FromBytes + Default,
 {
+    /// Gets a reference to the shared memory region data.
+    /// # Returns
+    /// Immutable reference.
     unsafe fn get_t(&self) -> &T;
+    
+    /// Gets a mutable reference to the shared memory region data.
+    /// # Returns
+    /// Mutable reference.
     unsafe fn get_t_mut(&mut self) -> &mut T;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,22 +192,15 @@ where
     map: sh::ShObj<T>,
 }
 
-impl<T> Deref for ShMem<T>
+impl<T> ShMemOps<T> for ShMem<T>
 where
     T: AsBytes + FromBytes + Default,
 {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
+    unsafe fn get_t(&self) -> &T {
         self.map.get_t()
     }
-}
 
-impl<T> DerefMut for ShMem<T>
-where
-    T: AsBytes + FromBytes + Default,
-{
-    fn deref_mut(&mut self) -> &mut Self::Target {
+    unsafe fn get_t_mut(&mut self) -> &mut T {
         self.map.get_t_mut()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ where
 {
     owner: bool,
     file_name: String,
+    init_value: Option<T>,
     _marker: PhantomData<T>,
 }
 
@@ -113,6 +114,7 @@ where
         Self {
             owner: false,
             file_name: name,
+            init_value: None,
             _marker: PhantomData,
         }
     }
@@ -149,6 +151,16 @@ where
     /// Mutable reference to the configurator.
     pub fn set_owner(mut self) -> Self {
         self.owner = true;
+        self
+    }
+
+    /// Sets the initial value of the shared memory region. If skipped, `T::default()` will be used.
+    /// # Params
+    /// `init`: Initial value
+    /// # Returns
+    /// Mutable reference to the configurator.
+    pub fn with_initial_value(mut self, init: T) -> Self {
+        self.init_value = Some(init);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ cfg_if::cfg_if! {
 }
 
 /// Configures and initilizes a shared memory region.
-/// By default, the segment name is ramdomly created and this instance is not the owner of the memory object.
+/// By default, the segment name is randomly created and this instance is not the owner of the memory object.
 /// # Example
 /// ```no_compile
 /// let memory = ShMemCfg::<u32>::default().build().unwrap();

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -37,8 +37,13 @@ where
         let data_ptr = map as *mut T;
 
         if value.owner {
+            let init = match value.init_value {
+                Some(v) => v,
+                None => T::default(),
+            };
+
             unsafe {
-                *data_ptr = T::default();
+                *data_ptr = init;
             }
         }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -75,12 +75,12 @@ impl<T> ShMemOps<T> for ShObj<T>
 where
     T: AsBytes + FromBytes + Default,
 {
-    fn get_t(&self) -> &T {
-        unsafe { &(*self.data) }
+    unsafe fn get_t(&self) -> &T {
+        &(*self.data)
     }
 
-    fn get_t_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.data }
+    unsafe fn get_t_mut(&mut self) -> &mut T {
+        &mut *self.data
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -34,7 +34,7 @@ where
             windows_fn::open_handle(name_utf16.as_mut_ptr())?
         };
 
-        let ptr = windows_fn::map_file_view::<T>(file_map_handle)? as *mut T;
+        let data_ptr = windows_fn::map_file_view::<T>(file_map_handle)? as *mut T;
 
         if value.owner {
             let init = match value.init_value {
@@ -48,7 +48,7 @@ where
         }
 
         Ok(ShObj {
-            data: ptr,
+            data: data_ptr,
             handle: file_map_handle,
             file_name: name_utf16,
             owner: value.owner,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -72,12 +72,12 @@ impl<T> ShMemOps<T> for ShObj<T>
 where
     T: AsBytes + FromBytes + Default,
 {
-    fn get_t(&self) -> &T {
-        unsafe { &(*self.data) }
+    unsafe fn get_t(&self) -> &T {
+        &(*self.data)
     }
 
-    fn get_t_mut(&mut self) -> &mut T {
-        unsafe { &mut (*self.data) }
+    unsafe fn get_t_mut(&mut self) -> &mut T {
+        &mut (*self.data)
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -37,8 +37,13 @@ where
         let ptr = windows_fn::map_file_view::<T>(file_map_handle)? as *mut T;
 
         if value.owner {
+            let init = match value.init_value {
+                Some(v) => v,
+                None => T::default(),
+            };
+
             unsafe {
-                *ptr = T::default();
+                *data_ptr = init;
             }
         }
 


### PR DESCRIPTION
ShMem doesn't have Deref and DerefMut because they were hidding unsafe blocks from the lib user.
Instead, the memory is now accessed through get_t() and get_t_mut() operations.